### PR TITLE
Remove base font size

### DIFF
--- a/fonts/remixicon.css
+++ b/fonts/remixicon.css
@@ -21,7 +21,6 @@
 
 [class^="remixicon-"], [class*=" remixicon-"] {
   font-family: 'remixicon' !important;
-  font-size: 16px;
   font-style: normal;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/fonts/remixicon.less
+++ b/fonts/remixicon.less
@@ -21,7 +21,6 @@
 
 [class^="remixicon-"], [class*=" remixicon-"] {
   font-family: 'remixicon' !important;
-  font-size: 16px;
   font-style: normal;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
Remix Icon should not set base font size by default. it should inherit font size from its parent.

in many other icon frameworks the font size is relative to parent not in px or rem. we could alternatively use 1em but that would be a waste (un-reasonable css style).

in this [example](https://codepen.io/ashfahan/pen/WqXaPg) the remix icon should have inherit font icon size from its parent icon but it didnt because font size for remix elements was already defined to be 16px.