### PR TITLE
Remove explicit fill so that it can be overridden in SVG symbols

### DIFF
--- a/icons/Device/sensor-fill.svg
+++ b/icons/Device/sensor-fill.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <g>
         <path fill="none" d="M0 0h24v24H0z"/>
-        <path fill="#000" d="M6 8v2h12V8h-3V2h2v4h5v2h-2v12a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V8H2V6h5V2h2v6H6zm7-6v6h-2V2h2z"/>
+        <path d="M6 8v2h12V8h-3V2h2v4h5v2h-2v12a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V8H2V6h5V2h2v6H6zm7-6v6h-2V2h2z"/>
     </g>
 </svg>

--- a/icons/System/checkbox-blank-circle-fill.svg
+++ b/icons/System/checkbox-blank-circle-fill.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <g>
         <path fill="none" d="M0 0h24v24H0z"/>
-        <circle cx="12" cy="12" r="10" fill="#000"/>
+        <circle cx="12" cy="12" r="10" />
     </g>
 </svg>


### PR DESCRIPTION
I noticed when I tried to use `ri-checkbox-blank-circle-fill` from the SVG sprite that the color was locked to black, so I couldn't override it with the `fill` attribute like for other icons. Looking through the generated sprite, I discovered the same issue with `ri-sensor-fill`.

I assume editing the base SVG is the right approach; not sure if it's possible (or advisable) for me to rebuild the fonts myself!