### PR TITLE
Changing "Checkbox Blank Circle Fill" icon to use an SVG "path" element rather than a SVG "circle" element

### DIFF
--- a/fonts/remixicon.symbol.svg
+++ b/fonts/remixicon.symbol.svg
@@ -1904,7 +1904,7 @@
 </symbol><symbol viewBox="0 0 24 24" id="ri-checkbox-blank-circle-fill">
     <g>
         <path fill="none" d="M0 0h24v24H0z"/>
-        <circle cx="12" cy="12" r="10"/>
+        <path d="M2,12a10,10 0 1,0 20,0a10,10 0 1,0 -20,0"/>
     </g>
 </symbol><symbol viewBox="0 0 24 24" id="ri-checkbox-blank-circle-line">
     <g>

--- a/icons/System/checkbox-blank-circle-fill.svg
+++ b/icons/System/checkbox-blank-circle-fill.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <g>
         <path fill="none" d="M0 0h24v24H0z"/>
-        <circle cx="12" cy="12" r="10"/>
+        <path d="M2,12a10,10 0 1,0 20,0a10,10 0 1,0 -20,0"/>
     </g>
 </svg>


### PR DESCRIPTION
Every icon within RemixIcon (except `checkbox-blank-circle-full.svg`) uses paths to define icons, as seen in `checkbox-blank-circle-line.svg`, recreated below:

```html
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
    <g>
        <path fill="none" d="M0 0h24v24H0z"/>
        <path d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm0-2a8 8 0 1 0 0-16 8 8 0 0 0 0 16z"/>
    </g>
</svg>
```

The one exception to this is `checkbox-blank-circle-full.svg`, which uses the `<circle>` element, as you can see reproduced below:

```html
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
    <g>
        <path fill="none" d="M0 0h24v24H0z"/>
        <circle cx="12" cy="12" r="10"/>
    </g>
</svg>
```
Using a [circle to path converter](http://complexdan.com/svg-circleellipse-to-path-converter/), I was able to change it to use paths instead. This might also fix the issue behind https://github.com/Remix-Design/RemixIcon/issues/285.

## Key benefits of the change suggested:
- All SVG icons would now use solely paths
- Other libraries (e.g. [remixicon-react](https://github.com/bayesimpact/remixicon-react/blob/main/scripts/generate.js#L82)) that generate React components based on the icons would be fixed, as their generate script assumes that the SVGs will have only paths 