### PR TITLE
Add `globe` tag to `global` icon

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -190,7 +190,7 @@
         "flag-off": "flag slash,旗帜关闭,标记取消",
         "flag-2": "banner,pin,mark,milestone,旗帜,旗子,国旗,标记,里程碑",
         "triangular-flag": "banner,pin,mark,milestone,旗帜,旗子,国旗,标记,里程碑",
-        "global": "earth,union,world,language,international,planet,地球,联合,世界,全球,语言,国际,星球",
+        "global": "earth,union,world,language,international,planet,globe,地球,联合,世界,全球,语言,国际,星球",
         "honour": "honor,glory,achievement,recognition,award,锦旗,荣誉,荣耀,军衔,成就,认可",
         "links": "connection,address,url,hyperlink,chain,联系,链接,地址,超链接,连接",
         "printer": "print,document,paper,output,打印机,打印,文档,纸张",


### PR DESCRIPTION
When I was looking for an icon like this the first search term I tried was globe, other similar icons have this tag.