### PR TITLE
fix(license): update license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "README_CN.md",
     "README.md"
   ],
-  "license": "Apache-2.0",
+  "license": "Remix Icon License v1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Remix-Design/remixicon.git"


### PR DESCRIPTION
## Related Issue

- #1069

## Summary

This PR updates the license metadata in package.json from `Apache-2.0` to `Remix Icon License v1.0`.

## Why

To ensure that the published package accurately reflects the correct project license. Some license tools, such as [license-checker-rseidelsohn](https://github.com/RSeidelsohn/license-checker-rseidelsohn), refer to `package.json`, so this update will assist users who are concerned about licensing.

## Impact

No runtime or functional changes. This is a metadata-only update.